### PR TITLE
refactor(auth): change token storage from sessionStorage to localStorage

### DIFF
--- a/src/api/auth/resetPasswordByAdmin.ts
+++ b/src/api/auth/resetPasswordByAdmin.ts
@@ -51,7 +51,7 @@ export const resetPasswordByAdmin = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             // Coba lagi setelah refresh token
             return await resetPasswordByAdmin(userID, newPassword)

--- a/src/api/auth/resetPasswordByUser.ts
+++ b/src/api/auth/resetPasswordByUser.ts
@@ -51,7 +51,7 @@ export const resetPasswordByUser = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             // Coba lagi setelah refresh token
             return await resetPasswordByUser(currentPassword, newPassword)

--- a/src/api/logout.ts
+++ b/src/api/logout.ts
@@ -37,7 +37,7 @@ export const logout = async (): Promise<LogoutResponseInterface> => {
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             return await logout()
           } else {

--- a/src/api/organizations/AddMember.ts
+++ b/src/api/organizations/AddMember.ts
@@ -50,7 +50,7 @@ export const addMemberOrganization = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             // Coba lagi setelah refresh token
             return await addMemberOrganization(userID, organizationID)

--- a/src/api/organizations/createOrganization.ts
+++ b/src/api/organizations/createOrganization.ts
@@ -50,7 +50,7 @@ export const createNewOrganization = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             // Coba lagi setelah refresh token
             return await createNewOrganization(newOrganizationData)

--- a/src/api/organizations/deleteOrganization.ts
+++ b/src/api/organizations/deleteOrganization.ts
@@ -47,7 +47,7 @@ export const deleteOrganization = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             return await deleteOrganization(organizationID)
           } else {

--- a/src/api/organizations/editOrganization.ts
+++ b/src/api/organizations/editOrganization.ts
@@ -54,7 +54,7 @@ export const updateOrganization = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             // Coba lagi setelah refresh token
             return await updateOrganization(newOrganizationData, organizationID)

--- a/src/api/organizations/getListOrganizations.ts
+++ b/src/api/organizations/getListOrganizations.ts
@@ -88,7 +88,7 @@ export const getListOrganization = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             return await getListOrganization(params)
           } else {

--- a/src/api/organizations/getMembers.ts
+++ b/src/api/organizations/getMembers.ts
@@ -59,7 +59,7 @@ export const getMembersOrganization = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             // Coba lagi setelah refresh token
             return await getMembersOrganization(organizationID)

--- a/src/api/organizations/getOrganizationDetail.ts
+++ b/src/api/organizations/getOrganizationDetail.ts
@@ -49,7 +49,7 @@ export const getOrganizationDetail = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             return await getOrganizationDetail(organizationID)
           } else {

--- a/src/api/quiz/index.ts
+++ b/src/api/quiz/index.ts
@@ -70,7 +70,7 @@ export class QuizService {
                 token: refreshResponse.data.token,
                 expires_at: refreshResponse.data.expires_at,
               }
-              sessionStorage.setItem('auth_token', JSON.stringify(auth))
+              localStorage.setItem('auth_token', JSON.stringify(auth))
 
               return await this.getAvailableQuizzes()
             } else {
@@ -123,7 +123,7 @@ export class QuizService {
                 token: refreshResponse.data.token,
                 expires_at: refreshResponse.data.expires_at,
               }
-              sessionStorage.setItem('auth_token', JSON.stringify(auth))
+              localStorage.setItem('auth_token', JSON.stringify(auth))
 
               return await this.getQuizDetail(quizId)
             } else {
@@ -166,7 +166,7 @@ export class QuizService {
                 token: refreshResponse.data.token,
                 expires_at: refreshResponse.data.expires_at,
               }
-              sessionStorage.setItem('auth_token', JSON.stringify(auth))
+              localStorage.setItem('auth_token', JSON.stringify(auth))
 
               return await this.getQuizSubmissions()
             } else {
@@ -219,7 +219,7 @@ export class QuizService {
                 token: refreshResponse.data.token,
                 expires_at: refreshResponse.data.expires_at,
               }
-              sessionStorage.setItem('auth_token', JSON.stringify(auth))
+              localStorage.setItem('auth_token', JSON.stringify(auth))
 
               return await this.getQuizResult(quizId)
             } else {
@@ -273,7 +273,7 @@ export class QuizService {
                 token: refreshResponse.data.token,
                 expires_at: refreshResponse.data.expires_at,
               }
-              sessionStorage.setItem('auth_token', JSON.stringify(auth))
+              localStorage.setItem('auth_token', JSON.stringify(auth))
 
               return await this.submitQuiz(submission)
             } else {
@@ -326,7 +326,7 @@ export class QuizService {
                 token: refreshResponse.data.token,
                 expires_at: refreshResponse.data.expires_at,
               }
-              sessionStorage.setItem('auth_token', JSON.stringify(auth))
+              localStorage.setItem('auth_token', JSON.stringify(auth))
 
               return await this.checkQuizSubmission(quizId)
             } else {

--- a/src/api/register.ts
+++ b/src/api/register.ts
@@ -61,7 +61,7 @@ export const registerNewUser = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             // Coba lagi setelah refresh token
             return await registerNewUser(newData, 1)

--- a/src/api/services/getAdminServices.ts
+++ b/src/api/services/getAdminServices.ts
@@ -32,7 +32,7 @@ export const getAdminServices = async (): Promise<AdminServicesResponse> => {
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             return await getAdminServices()
           } else {

--- a/src/api/services/getUserServices.ts
+++ b/src/api/services/getUserServices.ts
@@ -41,7 +41,7 @@ export const getUserService = async (userID?: string): Promise<UserServiceRespon
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             return await getUserService(userID)
           } else {

--- a/src/api/services/postUserService.ts
+++ b/src/api/services/postUserService.ts
@@ -49,7 +49,7 @@ export const postUserServiceData = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             return await postUserServiceData(newServiceData, userID)
           } else {

--- a/src/api/services/unlinkService.ts
+++ b/src/api/services/unlinkService.ts
@@ -49,7 +49,7 @@ export const unlinkService = async ({
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             // Coba lagi setelah refresh token
             return await unlinkService({ userID, codeService })

--- a/src/api/sessions/deleteSessionAll.ts
+++ b/src/api/sessions/deleteSessionAll.ts
@@ -45,7 +45,7 @@ export const deleteSessionAll = async (): Promise<ResponseAPIDeleteSessionAllInt
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             return await deleteSessionAll()
           } else {

--- a/src/api/sessions/deleteSessionSpecificByAdmin.ts
+++ b/src/api/sessions/deleteSessionSpecificByAdmin.ts
@@ -49,7 +49,7 @@ export const deleteSessionSpesificByAdmin = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             return await deleteSessionSpesificByAdmin(userID)
           } else {

--- a/src/api/sessions/deleteSessionSpecificByUser.ts
+++ b/src/api/sessions/deleteSessionSpecificByUser.ts
@@ -46,7 +46,7 @@ export const deleteSessionSpesificByUser = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             return await deleteSessionSpesificByUser(sessionID)
           } else {

--- a/src/api/sessions/getListSessions.ts
+++ b/src/api/sessions/getListSessions.ts
@@ -44,7 +44,7 @@ export const getListSession = async (): Promise<ResponseDataGETSessionFromAPI> =
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             return await getListSession()
           } else {

--- a/src/api/users/createUserBatch.ts
+++ b/src/api/users/createUserBatch.ts
@@ -84,7 +84,7 @@ export const batchRegisterUsers = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             // Coba lagi setelah refresh token
             return await batchRegisterUsers(users, source)

--- a/src/api/users/createUserCSV.ts
+++ b/src/api/users/createUserCSV.ts
@@ -64,7 +64,7 @@ export const RegisterUserByCSV = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             return await RegisterUserByCSV(CSVFile)
           } else {

--- a/src/api/users/editUser.ts
+++ b/src/api/users/editUser.ts
@@ -56,7 +56,7 @@ export const editUserData = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             // Coba lagi setelah refresh token
             return await editUserData(newUserData, userID, role)

--- a/src/api/users/getListUser.ts
+++ b/src/api/users/getListUser.ts
@@ -116,7 +116,7 @@ export const getListUser = async (
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             return await getListUser(params)
           } else {

--- a/src/api/users/getProfile.ts
+++ b/src/api/users/getProfile.ts
@@ -35,7 +35,7 @@ export const getProfile = async (): Promise<{user: UserDataInterface}> => {
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             return await getProfile()
           } else {

--- a/src/api/users/getUserProfileById.ts
+++ b/src/api/users/getUserProfileById.ts
@@ -35,7 +35,7 @@ export const getProfileByID = async (user_id: string): Promise<{ user: UserDataI
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             return await getProfileByID(user_id)
           } else {

--- a/src/api/users/updateProfile.ts
+++ b/src/api/users/updateProfile.ts
@@ -54,7 +54,7 @@ export const updateProfile = async (payload: UpdateProfilePayload): Promise<{use
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             return await updateProfile(payload)
           } else {

--- a/src/lib/httpClient.ts
+++ b/src/lib/httpClient.ts
@@ -83,7 +83,7 @@ class HTTPClient {
               token: refreshResponse.data.token,
               expires_at: refreshResponse.data.expires_at,
             }
-            sessionStorage.setItem('auth_token', JSON.stringify(auth))
+            localStorage.setItem('auth_token', JSON.stringify(auth))
 
             // Retry the original request with new token
             return await this.makeRequest<T>(url, options, false)

--- a/src/stores/userStores.ts
+++ b/src/stores/userStores.ts
@@ -57,10 +57,10 @@ export const useUserStore = defineStore('user', () => {
     isAuthenticated.value = true
     isInitialized.value = true
 
-    // Store in sessionStorage for session-based persistence (security best practice)
-    sessionStorage.setItem('auth_token', JSON.stringify(authData.auth))
-    sessionStorage.setItem('data_user', JSON.stringify(authData.user))
-    sessionStorage.setItem('data_services', JSON.stringify(authData.services))
+    // Store in localStorage for persistent authentication across tabs
+    localStorage.setItem('auth_token', JSON.stringify(authData.auth))
+    localStorage.setItem('data_user', JSON.stringify(authData.user))
+    localStorage.setItem('data_services', JSON.stringify(authData.services))
   }
 
   const setUserProfileData = (userData: Partial<UserLoginInterface>) => {
@@ -70,23 +70,23 @@ export const useUserStore = defineStore('user', () => {
         ...user.value,
         ...userData,
       }
-      // Perbarui data_user di sessionStorage
-      sessionStorage.setItem('data_user', JSON.stringify(user.value))
+      // Perbarui data_user di localStorage
+      localStorage.setItem('data_user', JSON.stringify(user.value))
     } else {
       // Jika user.value belum ada, inisialisasi dengan userData
       user.value = userData as UserLoginInterface
-      sessionStorage.setItem('data_user', JSON.stringify(userData))
+      localStorage.setItem('data_user', JSON.stringify(userData))
     }
   }
 
   const setTempVerificationToken = (token: string) => {
     tempVerificationToken.value = token
-    sessionStorage.setItem('temp_verification_token', token)
+    localStorage.setItem('temp_verification_token', token)
   }
 
   const clearTempVerificationToken = () => {
     tempVerificationToken.value = null
-    sessionStorage.removeItem('temp_verification_token')
+    localStorage.removeItem('temp_verification_token')
   }
 
   const clearUserData = () => {
@@ -97,10 +97,10 @@ export const useUserStore = defineStore('user', () => {
     tempVerificationToken.value = null
     isInitialized.value = false
 
-    sessionStorage.removeItem('auth_token')
-    sessionStorage.removeItem('data_user')
-    sessionStorage.removeItem('data_services')
-    sessionStorage.removeItem('temp_verification_token')
+    localStorage.removeItem('auth_token')
+    localStorage.removeItem('data_user')
+    localStorage.removeItem('data_services')
+    localStorage.removeItem('temp_verification_token')
   }
 
   const isTokenValid = (): boolean => {
@@ -134,10 +134,10 @@ export const useUserStore = defineStore('user', () => {
     isInitializing.value = true
 
     try {
-      const storedToken = sessionStorage.getItem('auth_token')
-      const storedUser = sessionStorage.getItem('data_user')
-      const storedServices = sessionStorage.getItem('data_services')
-      const storedTempToken = sessionStorage.getItem('temp_verification_token')
+      const storedToken = localStorage.getItem('auth_token')
+      const storedUser = localStorage.getItem('data_user')
+      const storedServices = localStorage.getItem('data_services')
+      const storedTempToken = localStorage.getItem('temp_verification_token')
 
       // Restore temporary verification token if it exists
       if (storedTempToken) {


### PR DESCRIPTION
Switch auth token storage mechanism to localStorage for persistent authentication across browser tabs and sessions